### PR TITLE
fix get previous values that where calling float getters

### DIFF
--- a/bow/bowgetters.go
+++ b/bow/bowgetters.go
@@ -107,8 +107,8 @@ func (b *bow) GetPreviousValues(col1, col2, row int) (interface{}, interface{}, 
 
 	for row >= 0 && row < b.NumRows() {
 		var v1 interface{}
-		v1, row = b.GetPreviousFloat64(col1, row)
-		v2, row2 := b.GetPreviousFloat64(col2, row)
+		v1, row = b.GetPreviousValue(col1, row)
+		v2, row2 := b.GetPreviousValue(col2, row)
 		if row == row2 {
 			return v1, v2, row
 		}

--- a/bow/fill/linear_test.go
+++ b/bow/fill/linear_test.go
@@ -58,33 +58,6 @@ func TestLinear(t *testing.T) {
 			fmt.Sprintf("expected %s\nactual %s", expected.String(), filled.String()))
 	})
 
-	t.Run("descendant no options", func(t *testing.T) {
-		b, err := bow.NewBowFromColumnBasedInterfaces([]string{timeCol, valueCol}, []bow.Type{bow.Int64, bow.String}, [][]interface{}{
-			{10, 15},
-			{"test", "test2"},
-		})
-		require.NoError(t, err)
-		r, _ := rolling.IntervalRolling(b, timeCol, rollInterval, rolling.Options{})
-		_, err = r.
-			Fill(WindowStart(timeCol), Linear(valueCol)).
-			Bow()
-		assert.EqualError(t, err, "fill: interpolation accepts types [int64 float64], got type utf8")
-	})
-
-	t.Run("descendant no options", func(t *testing.T) {
-		b, err := bow.NewBowFromColumnBasedInterfaces([]string{timeCol, valueCol}, []bow.Type{bow.Int64, bow.Bool}, [][]interface{}{
-			{10, 15},
-			{true, false},
-		})
-		require.NoError(t, err)
-		r, _ := rolling.IntervalRolling(b, timeCol, rollInterval, rolling.Options{})
-		res, err := r.
-			Fill(WindowStart(timeCol), Linear(valueCol)).
-			Bow()
-		assert.EqualError(t, err, "fill: interpolation accepts types [int64 float64], got type bool",
-			"have res: %v", res)
-	})
-
 	t.Run("ascendant with offset", func(t *testing.T) {
 		r, _ := rolling.IntervalRolling(ascendantLinearTestBow, timeCol, rollInterval, rolling.Options{Offset: 3.})
 		filled, err := r.
@@ -117,4 +90,30 @@ func TestLinear(t *testing.T) {
 			fmt.Sprintf("expected %s\nactual %s", expected.String(), filled.String()))
 	})
 
+	t.Run("string error", func(t *testing.T) {
+		b, err := bow.NewBowFromColumnBasedInterfaces([]string{timeCol, valueCol}, []bow.Type{bow.Int64, bow.String}, [][]interface{}{
+			{10, 15},
+			{"test", "test2"},
+		})
+		require.NoError(t, err)
+		r, _ := rolling.IntervalRolling(b, timeCol, rollInterval, rolling.Options{})
+		_, err = r.
+			Fill(WindowStart(timeCol), Linear(valueCol)).
+			Bow()
+		assert.EqualError(t, err, "fill: interpolation accepts types [int64 float64], got type utf8")
+	})
+
+	t.Run("bool error", func(t *testing.T) {
+		b, err := bow.NewBowFromColumnBasedInterfaces([]string{timeCol, valueCol}, []bow.Type{bow.Int64, bow.Bool}, [][]interface{}{
+			{10, 15},
+			{true, false},
+		})
+		require.NoError(t, err)
+		r, _ := rolling.IntervalRolling(b, timeCol, rollInterval, rolling.Options{})
+		res, err := r.
+			Fill(WindowStart(timeCol), Linear(valueCol)).
+			Bow()
+		assert.EqualError(t, err, "fill: interpolation accepts types [int64 float64], got type bool",
+			"have res: %v", res)
+	})
 }

--- a/bow/fill/linear_test.go
+++ b/bow/fill/linear_test.go
@@ -2,6 +2,7 @@ package fill
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"log"
 	"testing"
 
@@ -55,6 +56,33 @@ func TestLinear(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, expected.String(), filled.String(),
 			fmt.Sprintf("expected %s\nactual %s", expected.String(), filled.String()))
+	})
+
+	t.Run("descendant no options", func(t *testing.T) {
+		b, err := bow.NewBowFromColumnBasedInterfaces([]string{timeCol, valueCol}, []bow.Type{bow.Int64, bow.String}, [][]interface{}{
+			{10, 15},
+			{"test", "test2"},
+		})
+		require.NoError(t, err)
+		r, _ := rolling.IntervalRolling(b, timeCol, rollInterval, rolling.Options{})
+		_, err = r.
+			Fill(WindowStart(timeCol), Linear(valueCol)).
+			Bow()
+		assert.EqualError(t, err, "fill: interpolation accepts types [int64 float64], got type utf8")
+	})
+
+	t.Run("descendant no options", func(t *testing.T) {
+		b, err := bow.NewBowFromColumnBasedInterfaces([]string{timeCol, valueCol}, []bow.Type{bow.Int64, bow.Bool}, [][]interface{}{
+			{10, 15},
+			{true, false},
+		})
+		require.NoError(t, err)
+		r, _ := rolling.IntervalRolling(b, timeCol, rollInterval, rolling.Options{})
+		res, err := r.
+			Fill(WindowStart(timeCol), Linear(valueCol)).
+			Bow()
+		assert.EqualError(t, err, "fill: interpolation accepts types [int64 float64], got type bool",
+			"have res: %v", res)
 	})
 
 	t.Run("ascendant with offset", func(t *testing.T) {

--- a/bow/fill/stepprevious.go
+++ b/bow/fill/stepprevious.go
@@ -6,15 +6,9 @@ import (
 )
 
 func StepPrevious(colName string) rolling.ColumnInterpolation {
-	var lastVal interface{}
-
-	return rolling.NewColumnInterpolation(colName, []bow.Type{bow.Int64, bow.Float64, bow.Bool},
+	return rolling.NewColumnInterpolation(colName, []bow.Type{bow.Int64, bow.Float64, bow.Bool, bow.String},
 		func(inputCol int, w bow.Window, full bow.Bow) (interface{}, error) {
-			if w.FirstIndex == -1 {
-				return lastVal, nil
-			}
 			_, v, _ := full.GetPreviousValues(w.IntervalColumnIndex, inputCol, w.FirstIndex-1)
-			lastVal = w.Bow.GetValue(inputCol, w.Bow.NumRows()-1)
 			return v, nil
 		},
 	)

--- a/bow/fill/stepprevious_test.go
+++ b/bow/fill/stepprevious_test.go
@@ -33,6 +33,42 @@ func TestStepPrevious(t *testing.T) {
 			fmt.Sprintf("expected %s\nactual %s", expected.String(), filled.String()))
 	})
 
+	t.Run("bool", func(t *testing.T) {
+		b, _ := bow.NewBowFromColumnBasedInterfaces([]string{timeCol, valueCol}, []bow.Type{bow.Int64, bow.Bool}, [][]interface{}{
+			{10, 13},
+			{true, false},
+		})
+		r, _ := rolling.IntervalRolling(b, timeCol, 2, rolling.Options{})
+		filled, err := r.
+			Fill(WindowStart(timeCol), StepPrevious(valueCol)).
+			Bow()
+		expected, _ := bow.NewBowFromColumnBasedInterfaces([]string{timeCol, valueCol}, []bow.Type{bow.Int64, bow.Bool}, [][]interface{}{
+			{10, 12, 13},
+			{true, true, false},
+		})
+		assert.Nil(t, err)
+		assert.True(t, filled.Equal(expected),
+			fmt.Sprintf("expected %s\nactual %s", expected.String(), filled.String()))
+	})
+
+	t.Run("string", func(t *testing.T) {
+		b, _ := bow.NewBowFromColumnBasedInterfaces([]string{timeCol, valueCol}, []bow.Type{bow.Int64, bow.String}, [][]interface{}{
+			{10, 13},
+			{"test", "test2"},
+		})
+		r, _ := rolling.IntervalRolling(b, timeCol, 2, rolling.Options{})
+		filled, err := r.
+			Fill(WindowStart(timeCol), StepPrevious(valueCol)).
+			Bow()
+		expected, _ := bow.NewBowFromColumnBasedInterfaces([]string{timeCol, valueCol}, []bow.Type{bow.Int64, bow.String}, [][]interface{}{
+			{10, 12, 13},
+			{"test", "test", "test2"},
+		})
+		assert.Nil(t, err)
+		assert.True(t, filled.Equal(expected),
+			fmt.Sprintf("expected %s\nactual %s", expected.String(), filled.String()))
+	})
+
 	t.Run("with offset", func(t *testing.T) {
 		b, _ := bow.NewBowFromColumnBasedInterfaces([]string{timeCol, valueCol}, []bow.Type{bow.Int64, bow.Float64}, [][]interface{}{
 			{10, 13},

--- a/bow/rolling/rolling.go
+++ b/bow/rolling/rolling.go
@@ -157,12 +157,10 @@ func (it *intervalRollingIterator) Next() (windowIndex int, w *bow.Window, err e
 	start := it.currStart
 	end := it.currStart + it.interval // include last position even if last point is excluded
 
-	firstIndex := -1
-	lastIndex := -1
-
+	firstIndex, lastIndex := it.currIndex, -1
 	var i int
 	var isInclusive bool
-	for i = it.currIndex; i < it.bow.NumRows(); i++ {
+	for i = firstIndex; i < it.bow.NumRows(); i++ {
 		ref, ok := it.bow.GetInt64(it.column, i)
 		if !ok {
 			continue
@@ -181,9 +179,6 @@ func (it *intervalRollingIterator) Next() (windowIndex int, w *bow.Window, err e
 			isInclusive = true
 		}
 
-		if firstIndex == -1 {
-			firstIndex = i
-		}
 		lastIndex = i
 	}
 
@@ -192,12 +187,13 @@ func (it *intervalRollingIterator) Next() (windowIndex int, w *bow.Window, err e
 	} else {
 		it.currIndex = i - 1
 	}
+
 	it.currStart = end
 	windowIndex = it.windowIndex
 	it.windowIndex++
 
 	var b bow.Bow
-	if firstIndex == -1 {
+	if lastIndex == -1 {
 		b = it.bow.NewEmpty()
 	} else {
 		b = it.bow.NewSlice(firstIndex, lastIndex+1)

--- a/bow/rolling/rolling_test.go
+++ b/bow/rolling/rolling_test.go
@@ -153,16 +153,8 @@ func TestIntervalRolling_iterator_init(t *testing.T) {
 func TestIntervalRolling_iterate(t *testing.T) {
 	var interval int64 = 5
 	b := newIntervalRollingTestBow([][]interface{}{
-		{
-			12,
-			15, 16,
-			25, 29,
-		},
-		{
-			1.2,
-			1.5, 1.6,
-			2.5, 2.9,
-		},
+		{12, 15, 16, 25, 29},
+		{1.2, 1.5, 1.6, 2.5, 2.9},
 	})
 
 	t.Run("no option", func(t *testing.T) {
@@ -174,7 +166,7 @@ func TestIntervalRolling_iterate(t *testing.T) {
 		expected := []testWindow{
 			{0, 10, 15, 0, [][]interface{}{{12}, {1.2}}},
 			{1, 15, 20, 1, [][]interface{}{{15, 16}, {1.5, 1.6}}},
-			{2, 20, 25, -1, emptyCols},
+			{2, 20, 25, 3, emptyCols},
 			{3, 25, 30, 3, [][]interface{}{{25, 29}, {2.5, 2.9}}},
 		}
 
@@ -239,7 +231,7 @@ func TestIntervalRolling_iterate(t *testing.T) {
 
 		expected := []testWindow{
 			{0, 12, 17, 0, [][]interface{}{{12, 15, 16}, {1.2, 1.5, 1.6}}},
-			{1, 17, 22, -1, emptyCols},
+			{1, 17, 22, 3, emptyCols},
 			{2, 22, 27, 3, [][]interface{}{{25}, {2.5}}},
 			{3, 27, 32, 4, [][]interface{}{{29}, {2.9}}},
 		}
@@ -262,7 +254,7 @@ func TestIntervalRolling_iterate(t *testing.T) {
 		expected := []testWindow{
 			{0, 8, 13, 0, [][]interface{}{{12}, {1.2}}},
 			{1, 13, 18, 1, [][]interface{}{{15, 16}, {1.5, 1.6}}},
-			{2, 18, 23, -1, emptyCols},
+			{2, 18, 23, 3, emptyCols},
 			{3, 23, 28, 3, [][]interface{}{{25}, {2.5}}},
 			{4, 28, 33, 4, [][]interface{}{{29}, {2.9}}},
 		}
@@ -285,7 +277,7 @@ func TestIntervalRolling_iterate(t *testing.T) {
 		expected := []testWindow{
 			{0, 8, 13, 0, [][]interface{}{{12}, {1.2}}},
 			{1, 13, 18, 1, [][]interface{}{{15, 16}, {1.5, 1.6}}},
-			{2, 18, 23, -1, emptyCols},
+			{2, 18, 23, 3, emptyCols},
 			{3, 23, 28, 3, [][]interface{}{{25}, {2.5}}},
 			{4, 28, 33, 4, [][]interface{}{{29}, {2.9}}},
 		}
@@ -308,7 +300,7 @@ func TestIntervalRolling_iterate(t *testing.T) {
 		expected := []testWindow{
 			{0, 10, 15, 0, [][]interface{}{{12}, {1.2}}},
 			{1, 15, 20, 1, [][]interface{}{{15, 16}, {1.5, 1.6}}},
-			{2, 20, 25, -1, emptyCols},
+			{2, 20, 25, 3, emptyCols},
 			{3, 25, 30, 3, [][]interface{}{{25, 29}, {2.5, 2.9}}},
 		}
 
@@ -330,7 +322,7 @@ func TestIntervalRolling_iterate(t *testing.T) {
 		expected := []testWindow{
 			{0, 8, 13, 0, [][]interface{}{{12}, {1.2}}},
 			{1, 13, 18, 1, [][]interface{}{{15, 16}, {1.5, 1.6}}},
-			{2, 18, 23, -1, emptyCols},
+			{2, 18, 23, 3, emptyCols},
 			{3, 23, 28, 3, [][]interface{}{{25}, {2.5}}},
 			{4, 28, 33, 4, [][]interface{}{{29}, {2.9}}},
 		}
@@ -363,12 +355,7 @@ func checkTestWindow(t *testing.T, iter *intervalRollingIterator, expected testW
 	assert.Equal(t, expected.end, w.End)
 	assert.Equal(t, expected.firstIndex, w.FirstIndex)
 	b := newIntervalRollingTestBow(expected.cols)
-	// fmt.Println("")
-	// fmt.Println("expected", expected.windowIndex, expected.start, expected.end, expected.firstIndex)
-	// fmt.Println("actual  ", wi, w.Start, w.End, w.FirstIndex)
-	// fmt.Println("expected bow", b)
-	// fmt.Println("actual   bow", w.Bow)
-	assert.True(t, w.Bow.Equal(b))
+	assert.True(t, w.Bow.Equal(b), "expect: %v\nhave: %v", b, w.Bow)
 }
 
 func newIntervalRollingTestBow(cols [][]interface{}) bow.Bow {


### PR DESCRIPTION
empty windows firstIndex match next windows firstIndex to preserve windows location on full bow even if empty
refactor previous interpolation